### PR TITLE
chore: rebrand project to Okami

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Nexus
+Copyright (c) 2023 Okami Team
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <div align="center">
-  <h1>Nexus</h1>
+  <h1>Okami</h1>
   <p>A modern framework for building scalable React applications with TypeScript, Redux Toolkit, and Vite.</p>
   
   [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-  [![npm version](https://img.shields.io/npm/v/@nexus-dev/cli.svg)](https://www.npmjs.com/package/@nexus-dev/cli)
+  [![npm version](https://img.shields.io/npm/v/@okami-team/cli.svg)](https://www.npmjs.com/package/@okami-team/cli)
   [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
   <img src="https://img.shields.io/badge/React-20232A?style=for-the-badge&logo=react&logoColor=61DAFB" alt="React" />
@@ -36,11 +36,11 @@
 
 ```bash
 # Using npx
-npx @nexus-dev/cli new my-app
+npx @okami-team/cli new my-app
 
 # Or install globally
-npm install -g @nexus-dev/cli
-nexus new my-app
+npm install -g @okami-team/cli
+okami new my-app
 
 # Navigate to project
 cd my-app
@@ -170,7 +170,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## 📚 Learn More
 
-- [Nexus Documentation](https://nexus-docs.example.com)
+- [Okami Documentation](https://okami-docs.example.com)
 - [React Documentation](https://reactjs.org/)
 - [Redux Toolkit Documentation](https://redux-toolkit.js.org/)
 - [React Router Documentation](https://reactrouter.com/)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "nexus",
+  "name": "okami",
   "version": "1.0.0",
-  "description": "Nexus React Framework",
+  "description": "Okami React Framework",
   "private": false,
   "workspaces": [
     "packages/*"

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,10 +1,10 @@
-# Nexus CLI
+# Okami CLI
 
-The official command-line interface for Nexus, a modern framework that brings Angular-like features to React. This CLI helps you quickly scaffold and manage your Nexus applications.
+The official command-line interface for Okami, a modern framework that brings Angular-like features to React. This CLI helps you quickly scaffold and manage your Okami applications.
 
 ## Features
 
-- **Project Generation**: Create new Nexus projects with a single command
+- **Project Generation**: Create new Okami projects with a single command
 - **Component Generation**: Quickly generate components with decorators
 - **Service Generation**: Create injectable services with the DI container
 - **Page Generation**: Generate page components with routing setup
@@ -16,7 +16,7 @@ The official command-line interface for Nexus, a modern framework that brings An
 ### Global Installation (Recommended)
 
 ```bash
-npm install -g @nexus-dev/cli
+npm install -g @okami-team/cli
 ```
 
 ## Usage
@@ -24,7 +24,7 @@ npm install -g @nexus-dev/cli
 ### Create a New Project
 
 ```bash
-nexus new my-app
+okami new my-app
 cd my-app
 npm run dev
 ```

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "@nexus-dev/cli",
-  "version": "0.2.26",
-  "description": "CLI for Nexus React framework",
+  "name": "@okami-team/cli",
+  "version": "0.1.0",
+  "description": "CLI for Okami React framework",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
-    "nexus": "./dist/index.js"
+    "okami": "./dist/index.js"
   },
   "exports": {
     ".": "./dist/index.js",
@@ -76,12 +76,13 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/AnasEchoFanani/Nexus.git"
+    "url": "git+https://github.com/okami-team/okami.git"
   },
   "bugs": {
-    "url": "https://github.com/AnasEchoFanani/Nexus/issues"
+    "url": "https://github.com/okami-team/okami/issues"
   },
-  "author": "Nexus",
+  "homepage": "https://github.com/okami-team/okami#readme",
+  "author": "Okami Team",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -6,22 +6,22 @@ import shell from 'shelljs';
 
 export function NewCommand(): Command {
   const command = new Command('new')
-    .description('Create a new Nexus application')
+    .description('Create a new Okami application')
     .argument('<name>', 'Name of the application')
     .action(async (name: string) => {
-      // Display custom Nexus logo
+      // Display custom Okami logo
       console.log(
         chalk.cyanBright(`
-███╗   ██╗███████╗██╗    ██╗██╗   ██╗███████╗
-████╗  ██║██╔════╝ ██║  ██╔╝██║   ██║██╔════╝
-██╔██╗ ██║█████╗    █████╔╝ ██║   ██║███████╗
-██║╚██╗██║██╔══╝   ██╔  ██╗ ██║   ██║╚════██║
-██║ ╚████║███████╗██║    ██╗╚██████╔╝███████║
-╚═╝  ╚═══╝╚══════╝╚═╝    ╚═╝ ╚═════╝ ╚══════╝
+ ██████╗ ██╗  ██╗ █████╗ ███╗   ███╗██╗
+██╔═══██╗██║ ██╔╝██╔══██╗████╗ ████║██║
+██║   ██║█████╔╝ ███████║██╔████╔██║██║
+██║   ██║██╔═██╗ ██╔══██║██║╚██╔╝██║██║
+╚██████╔╝██║  ██╗██║  ██║██║ ╚═╝ ██║██║
+ ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝     ╚═╝╚═╝
 `)
       );
 
-      console.log(chalk.green(`Creating new Nexus application: ${name}\n`));
+      console.log(chalk.green(`Creating new Okami application: ${name}\n`));
 
       // Determine the current directory of this file (ESM import.meta.url)
       const currentFile = new URL(import.meta.url).pathname;
@@ -40,20 +40,20 @@ export function NewCommand(): Command {
         // Development
         resolve(currentDir, '../../../template'),
         // Global install (Windows)
-        resolve(process.execPath, '../../node_modules/@nexus-dev/cli/template'),
+        resolve(process.execPath, '../../node_modules/@okami-team/cli/template'),
         // Global install (Windows alternative)
-        resolve(process.env.APPDATA || '', 'npm/node_modules/@nexus-dev/cli/template'),
+        resolve(process.env.APPDATA || '', 'npm/node_modules/@okami-team/cli/template'),
         // Local install
-        resolve(process.cwd(), 'node_modules/@nexus-dev/cli/template'),
+        resolve(process.cwd(), 'node_modules/@okami-team/cli/template'),
         // Global install (Unix-like)
-        '/usr/local/lib/node_modules/@nexus-dev/cli/template',
-        '/usr/lib/node_modules/@nexus-dev/cli/template',
+        '/usr/local/lib/node_modules/@okami-team/cli/template',
+        '/usr/lib/node_modules/@okami-team/cli/template',
         // For npm/yarn workspaces - use current file's location to find node_modules
-        resolve(currentDir, '..', '..', '..', 'node_modules', '@nexus-dev', 'cli', 'template'),
+        resolve(currentDir, '..', '..', '..', 'node_modules', '@okami-team', 'cli', 'template'),
         // Another common global location on Windows
-        'C:\\Program Files\\nodejs\\node_modules\\@nexus-dev\\cli\\template',
-        // Fallback to the directory where the CLI is installed
-        resolve(process.execPath, '..', '..', 'lib', 'node_modules', '@nexus-dev', 'cli', 'template')
+        'C:\\Program Files\\nodejs\\node_modules\\@okami-team\\cli\\template',
+        // Another common global location on Unix-like
+        resolve(process.execPath, '..', '..', 'lib', 'node_modules', '@okami-team', 'cli', 'template')
       ].filter(Boolean);
 
       // Find the first existing template directory
@@ -114,7 +114,7 @@ export function NewCommand(): Command {
         process.exit(1);
       }
 
-      console.log(chalk.green(`\n✅ Success! Created Nexus app "${name}" at:`));
+      console.log(chalk.green(`\n✅ Success! Created Okami app "${name}" at:`));
       console.log(chalk.yellow(`  ${targetPath}\n`));
 
       console.log('Next steps:');

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -28,8 +28,8 @@ async function main() {
   const program = new Command();
 
   program
-    .name('nexus')
-    .description('Nexus CLI for React applications with Angular-like features')
+    .name('okami')
+    .description('Okami CLI for React applications with Angular-like features')
     .version(version, '-v, --version', 'output the current version');
 
   // Register commands

--- a/packages/cli/template/README.md
+++ b/packages/cli/template/README.md
@@ -1,6 +1,6 @@
-# Nexus Application
+# Okami Application
 
-This project was generated with [Nexus CLI](https://github.com/your-org/nexus).
+This project was generated with [Okami CLI](https://github.com/your-org/okami).
 
 ## Features
 
@@ -118,7 +118,7 @@ This project is configured to be deployed to Vercel, Netlify, or any static host
 
 ## Learn More
 
-- [Nexus Documentation](https://nexus-docs.example.com)
+- [Okami Documentation](https://okami-docs.example.com)
 - [React Documentation](https://reactjs.org/)
 - [Redux Toolkit Documentation](https://redux-toolkit.js.org/)
 - [React Router Documentation](https://reactrouter.com/)

--- a/packages/cli/template/package.json
+++ b/packages/cli/template/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nexus",
+  "name": "okami",
   "private": true,
   "version": "0.0.0",
   "type": "module",


### PR DESCRIPTION
- Rebranded the entire project, framework, and CLI from "Nexus" to "Okami".
- Updated all project names, descriptions, and commands across README.md, package.json, and CLI source files.
- Changed the npm package scope from @nexus-dev to @okami-team.
- Modified CLI command names (e.g., nexus to okami) and internal logic to align with the new branding.
- Updated copyright, author, repository URLs, and documentation links.
- This comprehensive rebrand signifies a new identity and direction for the project.